### PR TITLE
feat(license): add distribution license explicitly covering source code

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Komorebi License
 
-Version 1.0.0
+Version 2.0.0
 
 ## Acceptance
 
@@ -13,9 +13,20 @@ your licenses.
 The licensor grants you a copyright license for the software
 to do everything you might do with the software that would
 otherwise infringe the licensor's copyright in it for any
-permitted purpose. However, you may only make changes according
+permitted purpose. However, you may only distribute the source
+code of the software according to the [Distribution License](
+#distribution-license), you may only make changes according
 to the [Changes License](#changes-license), and you may not
-distribute the software or new works based on the software.
+otherwise distribute the software or new works based on the
+software.
+
+## Distribution License
+
+The licensor grants you an additional copyright license to
+distribute copies of the source code of the software. Your
+license to distribute covers distributing the source code of
+the software with changes permitted by the [Changes License](
+#changes-license).
 
 ## Changes License
 
@@ -95,4 +106,3 @@ software under these terms.
 
 **Use** means anything you do with the software requiring one
 of your licenses.
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ license.
 It has been modified to integrate a "Changes License" based on the "Changes and
 New Works License" of the
 [PolyForm-Noncommercial](https://github.com/polyformproject/polyform-licenses/blob/1.0.0/PolyForm-Noncommercial-1.0.0.md)
+license, a "Distribution License" for source code based on the "Distribution
+License" of the
+[PolyForm-Noncommercial](https://github.com/polyformproject/polyform-licenses/blob/1.0.0/PolyForm-Noncommercial-1.0.0.md)
 license, while also removing any use by noncommercial organizations from the
 enumerated list of Permitted Purposes.
 


### PR DESCRIPTION
Based on discussions since the publication of v1.0.0, this is a proposal for v2.0.0 which integrates a Distribution License specifically for "the source code of the software", again based on the [PolyForm Noncommercial 1.0.0 license](https://github.com/polyformproject/polyform-licenses/blob/1.0.0/PolyForm-Noncommercial-1.0.0.md#distribution-license).

The intention behind this change is to clarify that the creation and maintenance of personal forks of the licensed software, public or private, which may or may not include changes for any Permitted Purpose, is permitted under the license.